### PR TITLE
GitHub Pages hardening for v2 stability

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="refresh" content="0; url=./index.html">
+    <title>JPCanvas</title>
+    <script>
+      window.location.replace('./index.html');
+    </script>
+  </head>
+  <body>
+    <p>Redirecting to <a href="./index.html">JPCanvas</a>...</p>
+  </body>
+</html>

--- a/README.md
+++ b/README.md
@@ -75,10 +75,37 @@ If the page still feels heavy on very low-end devices:
 - reduce `BATCH_SIZE` in `js/jpc.js`
 - keep canvas dimensions bounded to viewport
 
+## GitHub Pages (v2 hardening)
+
+This repository is intended to publish from **GitHub Pages** as a project site:
+
+- URL: <https://cazucito.github.io/jpc/>
+- Source branch: `master`
+- Source folder: `/ (root)`
+
+Hardening added for deployment stability:
+
+- `.nojekyll` to serve static files directly
+- `404.html` redirect to `index.html` to reduce broken-route issues
+
+### Recommended Pages settings
+
+1. Go to **Settings → Pages**
+2. Under **Build and deployment**:
+   - Source: **Deploy from a branch**
+   - Branch: **master**
+   - Folder: **/ (root)**
+3. Save and wait ~1–2 minutes.
+
+### Troubleshooting
+
+- If old version appears, force refresh (`Ctrl/Cmd + Shift + R`)
+- Confirm branch/folder match exactly (`master` + `/root`)
+- Check Actions/Pages status if deployment is pending
+
 ## Roadmap (near-term)
 
 - User-selectable custom colors
-- Better GitHub Pages/deployment notes
 - Extended README with screenshots and contribution guide
 
 ## Author


### PR DESCRIPTION
## Summary

Implements incremental GitHub Pages hardening for the current v2 baseline.

## Changes

- Added `.nojekyll` to enforce static serving behavior
- Added `404.html` fallback redirect to `index.html`
- Documented GitHub Pages setup and troubleshooting in README

## Notes

No visual/UI changes. This is deployment stability and operational documentation only.

Closes #3
