### PR TITLE
Issue #5: let users choose a custom 3-color palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ JPCanvas renders abstract paintings by drawing thousands of random lines with co
   - `BWR2` (blue/white/red)
   - `RGB` (red/green/blue)
 - Navbar actions to re-render with different palettes
+- User-defined custom 3-color palette (Issue #5)
 - Performance optimizations to reduce UI freezing:
   - chunked rendering via `requestAnimationFrame`
   - render cancellation when a new draw starts
@@ -72,7 +73,8 @@ npx serve .
 1. Open the page.
 2. The initial painting renders automatically.
 3. Use **Iterations** in the navbar to switch palette mode.
-4. Each selection triggers a fresh render.
+4. Use the **Custom colors** panel to pick 3 colors and apply your own palette.
+5. Each selection triggers a fresh render.
 
 ## Performance notes
 

--- a/css/jpc.css
+++ b/css/jpc.css
@@ -33,3 +33,19 @@
   color: #00ff00;
     text-shadow: 1px 1px 1px #aaa;
 }
+
+.custom-colors-panel {
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 6px;
+  padding: 12px;
+  max-height: 320px;
+}
+
+.custom-colors-panel input[type="color"] {
+  width: 100%;
+  height: 34px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: transparent;
+  padding: 2px;
+}

--- a/index.html
+++ b/index.html
@@ -57,12 +57,22 @@
       <div class="row justify-content-center">
         <div class="col-md-1">&nbsp;</div>
 
-        <div id="containerCanvas" class="col-md-10 align-self-center"><canvas id="jpcanvas">NOT SUPPORTED</canvas></div>
-<!--        <div class="col-md-2 text-light  flex-grow-1 flex-fill">Choose three color<br>
-          <input type="checkbox" value="B-W-R"> B-W-R<br>
-          <input type="checkbox" value="B-W-R"> B-W-R<br>
-          <input type="checkbox" value="B-W-R"> B-W-R
-        </div>-->
+        <div id="containerCanvas" class="col-md-8 align-self-center"><canvas id="jpcanvas">NOT SUPPORTED</canvas></div>
+        <div class="col-md-2 text-light flex-grow-1 flex-fill custom-colors-panel">
+          <h6 class="mb-3">Custom colors</h6>
+          <form id="custom-color-form">
+            <label class="small d-block mb-2">Color 1
+              <input type="color" id="custom-color-1" value="#000000" class="form-control form-control-sm">
+            </label>
+            <label class="small d-block mb-2">Color 2
+              <input type="color" id="custom-color-2" value="#ffffff" class="form-control form-control-sm">
+            </label>
+            <label class="small d-block mb-3">Color 3
+              <input type="color" id="custom-color-3" value="#ff0000" class="form-control form-control-sm">
+            </label>
+            <button type="submit" class="btn btn-sm btn-outline-light btn-block">Apply custom palette</button>
+          </form>
+        </div>
         <div class="col-md-1">&nbsp;</div>
       </div>
     </section>

--- a/js/app.js
+++ b/js/app.js
@@ -68,11 +68,30 @@ function attachNavigationHandlers() {
   });
 }
 
+function attachCustomColorHandler() {
+  const form = document.getElementById('custom-color-form');
+  if (!form) return;
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const color1 = document.getElementById('custom-color-1')?.value;
+    const color2 = document.getElementById('custom-color-2')?.value;
+    const color3 = document.getElementById('custom-color-3')?.value;
+
+    const customPalette = [color1, color2, color3].filter(Boolean);
+    if (customPalette.length !== 3) return;
+
+    renderWithDefaults(customPalette);
+  });
+}
+
 export function init() {
   setupCanvas();
   renderWithDefaults(Default.colorSet());
   attachResizeHandler();
   attachNavigationHandlers();
+  attachCustomColorHandler();
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/js/color.js
+++ b/js/color.js
@@ -1,11 +1,15 @@
 export class ColorSet {
-  static getColorSet(name) {
+  static getColorSet(nameOrPalette) {
+    if (Array.isArray(nameOrPalette) && nameOrPalette.length > 0) {
+      return nameOrPalette;
+    }
+
     const colorSets = {
       BWR: ['black', 'white', 'red'],
       RGB: ['red', 'green', 'blue'],
       BWR2: ['blue', 'white', 'red']
     };
-    return colorSets[name] || colorSets.BWR;
+    return colorSets[nameOrPalette] || colorSets.BWR;
   }
 }
 

--- a/js/painter.js
+++ b/js/painter.js
@@ -80,6 +80,11 @@ export class JPPainter {
     const mainTitle = document.getElementById('mainTitle');
     if (!mainTitle) return;
 
+    if (Array.isArray(colorSet)) {
+      mainTitle.innerHTML = '<strong>JPCanvas <span class="white">(Custom)</span></strong>';
+      return;
+    }
+
     let newMainTitle = '';
     switch (colorSet) {
       case 'BWR':


### PR DESCRIPTION
## Summary

Implements Issue #5 by allowing users to select and apply a custom 3-color palette directly from the UI.

## What changed

- Added a **Custom colors** panel in `index.html` with 3 color pickers
- Added **Apply custom palette** action (form submit)
- Wired custom palette rendering in `app.js`
- Updated color handling to accept either named palette IDs or direct color arrays
- Updated title rendering to show `(Custom)` when a user palette is active
- Added minimal styling for the custom color panel in `css/jpc.css`
- Updated README features and usage instructions

## Scope

- Incremental change on current v2 baseline
- No major redesign, only functional UI addition for color selection

Closes #5
