### PR TITLE
UI v3-B: add elegant render controls + local preferences

### DIFF
--- a/css/jpc.css
+++ b/css/jpc.css
@@ -98,7 +98,49 @@ body {
   display: flex;
   align-items: center;
   gap: 8px;
+  margin-bottom: 10px;
+}
+
+.controls-panel {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(140px, 1fr));
+  gap: 10px;
   margin-bottom: 12px;
+}
+
+.control-item {
+  display: grid;
+  gap: 4px;
+  background: var(--panel-soft);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 0.82rem;
+  color: var(--text-dim);
+}
+
+.control-item input[type="range"] {
+  width: 100%;
+}
+
+.control-value {
+  color: var(--text);
+  font-size: 0.8rem;
+}
+
+.btn-reset {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-dim);
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.btn-reset:hover {
+  border-color: var(--accent);
+  color: var(--accent-strong);
 }
 
 .meta-label {
@@ -157,4 +199,5 @@ body {
   .app-shell { width: min(1160px, 100% - 18px); }
   .topbar { padding: 12px; }
   .canvas-card { padding: 10px; }
+  .controls-panel { grid-template-columns: 1fr; }
 }

--- a/index.html
+++ b/index.html
@@ -32,6 +32,20 @@
           <span id="render-status" class="status-badge">Ready</span>
         </div>
 
+        <div class="controls-panel" aria-label="Render controls">
+          <label class="control-item">Lines
+            <input id="line-count" type="range" min="2000" max="18000" step="500" value="9000">
+            <span id="line-count-value" class="control-value">9000</span>
+          </label>
+
+          <label class="control-item">Stroke
+            <input id="stroke-width" type="range" min="1" max="4" step="1" value="2">
+            <span id="stroke-width-value" class="control-value">2</span>
+          </label>
+
+          <button id="reset-defaults" type="button" class="btn-reset">Reset defaults</button>
+        </div>
+
         <div id="containerCanvas" class="canvas-container">
           <canvas id="jpcanvas">NOT SUPPORTED</canvas>
         </div>

--- a/js/app.js
+++ b/js/app.js
@@ -138,29 +138,30 @@ function attachControlHandlers() {
   const strokeValue = document.getElementById('stroke-width-value');
   const resetBtn = document.getElementById('reset-defaults');
 
+  let controlRenderTimer = null;
+  const scheduleRender = () => {
+    clearTimeout(controlRenderTimer);
+    controlRenderTimer = setTimeout(() => {
+      persistPreferences();
+      renderWithDefaults(AppState.lastColorSet);
+    }, 120);
+  };
+
   if (lineInput && lineValue) {
     lineInput.addEventListener('input', () => {
       const value = Number(lineInput.value);
+      PerformanceConfig.DEFAULT_LINES = value;
       lineValue.textContent = String(value);
-    });
-
-    lineInput.addEventListener('change', () => {
-      PerformanceConfig.DEFAULT_LINES = Number(lineInput.value);
-      persistPreferences();
-      renderWithDefaults(AppState.lastColorSet);
+      scheduleRender();
     });
   }
 
   if (strokeInput && strokeValue) {
     strokeInput.addEventListener('input', () => {
       const value = Number(strokeInput.value);
+      PerformanceConfig.STROKE_WIDTH = value;
       strokeValue.textContent = String(value);
-    });
-
-    strokeInput.addEventListener('change', () => {
-      PerformanceConfig.STROKE_WIDTH = Number(strokeInput.value);
-      persistPreferences();
-      renderWithDefaults(AppState.lastColorSet);
+      scheduleRender();
     });
   }
 


### PR DESCRIPTION
## Summary

Phase B for the modern UI proposal. This PR builds on **v3-A** and adds lightweight, elegant controls without changing the core visual direction.

## Added

- Render controls panel:
  - Line count slider
  - Stroke width slider
  - Reset defaults button
- Live value labels for controls
- Persisted preferences in `localStorage`
- Regenerate + preset workflow kept intact
- Render status badge remains visible (`Rendering... / Ready`)

## Notes

- Base branch: `feature/ui-modern-v3-a`
- This is a stacked PR intended to merge after/with v3-A
