### PR TITLE
refactor(config): freeze constants and extract user preferences

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,46 +1,84 @@
-# JPCanvas Architecture (v2 incremental refactor)
-
-This document describes the architecture refactor introduced for Issue #10 (Phases A and B).
+# JPCanvas Architecture (v3 refactor)
 
 ## Goals
 
 - Improve readability and maintainability
 - Separate concerns by responsibility
-- Keep backward compatibility with existing UI actions
-- Preserve current visual behavior
+- Make the renderer pure and free of global state
+- Enable extensibility without modifying core modules
+- Keep backward compatibility with existing UI
 
 ## JavaScript layout (ES Modules)
 
-- `js/config.js` → performance/runtime constants
-- `js/state.js` → mutable app runtime state
-- `js/util.js` → generic helpers
-- `js/color.js` → palettes + color selection
-- `js/painter.js` → canvas drawing engine
-- `js/app.js` → app bootstrap, canvas sizing, resize orchestration, navbar bindings
+| Module | Responsibility |
+|---|---|
+| `js/config.js` | Immutable rendering constants (frozen object) |
+| `js/preferences.js` | User-adjustable values, defaults, and localStorage persistence |
+| `js/state.js` | Minimal mutable runtime state (canvas context, abort controller) |
+| `js/util.js` | Generic helpers |
+| `js/color.js` | Extensible palette registry (`ColorRegistry`) |
+| `js/ui.js` | DOM update functions (title, status badge, controls) |
+| `js/painter.js` | Pure canvas rendering engine — no DOM, no global state |
+| `js/app.js` | Bootstrap, canvas sizing, event wiring (orchestrator) |
 
-`index.html` now loads only:
+`index.html` loads only:
 
-- `<script type="module" src="js/app.js"></script>`
+```html
+<script type="module" src="js/app.js"></script>
+```
+
+## Unidirectional data flow
+
+```
+UserPreferences  (source of truth for user settings)
+       │
+   app.js        (orchestrator — owns render() lifecycle)
+       │                    │
+  JPPainter           UI object
+  (canvas only)       (DOM only — ui.js)
+```
 
 ## Runtime flow
 
-1. `DOMContentLoaded` triggers `init()` (from `app.js`)
-2. `setupCanvas()` computes bounded canvas dimensions
-3. `JPPainter.createPaintingA(...)` draws in chunked frames
-4. Resize events are debounced and trigger controlled redraw
-5. New renders cancel in-flight render tokens to avoid overlap
+1. `DOMContentLoaded` → `init()` in `app.js`
+2. `UserPreferences.load()` restores persisted settings from `localStorage`
+3. `setupCanvas()` computes bounded canvas dimensions
+4. `render(colorSet)` drives the full cycle:
+   - Aborts any in-flight render via `AbortController`
+   - Updates `UserPreferences.colorSet` and persists all settings
+   - Updates UI: title, status badge, active preset chip
+   - Calls `JPPainter.render(...)` with explicit parameters
+   - `onComplete` callback fires `UI.setRenderStatus(false)` on actual completion
+5. Resize events are debounced and re-invoke `setupCanvas()` + `render()`
+
+## Render cancellation
+
+`AbortController` / `AbortSignal` replaces the previous ad-hoc token object.
+`AppState.renderController.abort()` cancels the previous render before starting
+a new one. Each `drawChunk` iteration checks `signal.aborted` before continuing.
+
+## Extending palettes
+
+Register new palettes from any module without touching `color.js`:
+
+```js
+import { ColorRegistry } from './js/color.js';
+ColorRegistry.register('CMY', ['cyan', 'magenta', 'yellow']);
+```
+
+Registered palettes are immediately available to `ColorRegistry.random()`.
 
 ## Event architecture
 
-The previous inline `javascript:` navbar handlers were removed.
+Navigation and control elements use declarative `data-action` attributes:
 
-Navigation items now use declarative data attributes:
+- `data-action="render"` + `data-colorset="BWR|BWR2|RGB"`
+- `data-action="regenerate"`
 
-- `data-action="render"`
-- `data-colorset="BWR|BWR2|RGB"`
+`app.js` binds all handlers at startup and routes every user action through
+the single `render()` function.
 
-`app.js` binds click handlers at startup and routes rendering through one orchestration flow.
+## Compatibility
 
-## Compatibility note
-
-This phase intentionally modernizes runtime loading to ESM and removes the legacy global-driven execution path.
+Requires browsers with support for ES modules, `AbortController`, `Map`,
+optional chaining (`?.`), and `requestAnimationFrame`.

--- a/js/color.js
+++ b/js/color.js
@@ -1,17 +1,24 @@
-export class ColorSet {
-  static getColorSet(name) {
-    const colorSets = {
-      BWR: ['black', 'white', 'red'],
-      RGB: ['red', 'green', 'blue'],
-      BWR2: ['blue', 'white', 'red']
-    };
-    return colorSets[name] || colorSets.BWR;
-  }
-}
+const PALETTES = new Map([
+  ['BWR',  ['black', 'white', 'red']],
+  ['BWR2', ['blue',  'white', 'red']],
+  ['RGB',  ['red',   'green', 'blue']],
+]);
 
-export class ColorHandler {
-  static getRandomColor(colorSet) {
-    const set = ColorSet.getColorSet(colorSet);
+export const ColorRegistry = {
+  register(name, colors) {
+    PALETTES.set(name, [...colors]);
+  },
+
+  get(name) {
+    return PALETTES.get(name) ?? PALETTES.get('BWR');
+  },
+
+  random(name) {
+    const set = ColorRegistry.get(name);
     return set[Math.floor(Math.random() * set.length)];
-  }
-}
+  },
+
+  names() {
+    return [...PALETTES.keys()];
+  },
+};

--- a/js/config.js
+++ b/js/config.js
@@ -1,10 +1,8 @@
-export const PerformanceConfig = {
-  DEFAULT_LINES: 9000,
+export const PerformanceConfig = Object.freeze({
   BATCH_SIZE: 250,
-  STROKE_WIDTH: 2,
   FRAME_BUDGET_MS: 10,
   MIN_CANVAS_HEIGHT: 240,
   MAX_CANVAS_HEIGHT: 1400,
   CANVAS_VERTICAL_PADDING: 130,
-  RESIZE_DEBOUNCE_MS: 200
-};
+  RESIZE_DEBOUNCE_MS: 200,
+});

--- a/js/painter.js
+++ b/js/painter.js
@@ -1,100 +1,57 @@
-import { AppState } from './state.js';
 import { PerformanceConfig } from './config.js';
-import { Util } from './util.js';
-import { ColorHandler } from './color.js';
+import { Util }              from './util.js';
+import { ColorRegistry }     from './color.js';
 
 export class JPPainter {
-  static drawLine(ctx, widthLine, colorLine, origCoord, targetCoord) {
-    if (!colorLine) return;
+  static drawLine(ctx, { strokeWidth, color, from, to }) {
+    if (!color) return;
     ctx.beginPath();
-    ctx.lineWidth = widthLine;
-    ctx.strokeStyle = colorLine;
+    ctx.lineWidth     = strokeWidth;
+    ctx.strokeStyle   = color;
     ctx.shadowOffsetX = 1;
     ctx.shadowOffsetY = 1;
-    ctx.shadowBlur = 1;
-    ctx.shadowColor = 'gray';
-    ctx.moveTo(origCoord.x, origCoord.y);
-    ctx.lineTo(targetCoord.x, targetCoord.y);
+    ctx.shadowBlur    = 1;
+    ctx.shadowColor   = 'gray';
+    ctx.moveTo(from.x, from.y);
+    ctx.lineTo(to.x, to.y);
     ctx.stroke();
   }
 
-  static createPaintingA(canvas, howManyLines, colorSet) {
-    if (!canvas) return;
-
-    const ctx = AppState.ctx || canvas.getContext('2d');
-    AppState.lastColorSet = colorSet || 'BWR';
-
-    if (AppState.activeRenderToken) {
-      AppState.activeRenderToken.cancelled = true;
-    }
-
-    const renderToken = { cancelled: false };
-    AppState.activeRenderToken = renderToken;
+  static render({ ctx, canvas, totalLines, strokeWidth, colorSet, onComplete, signal }) {
+    if (!ctx || !canvas) return;
 
     ctx.clearRect(0, 0, canvas.width, canvas.height);
-    JPPainter.paintMainTitle(AppState.lastColorSet);
 
-    let renderedLines = 0;
-    const totalLines = Math.max(0, Number(howManyLines) || 0);
+    let rendered = 0;
+    const total  = Math.max(0, Number(totalLines) || 0);
 
     const drawChunk = () => {
-      if (renderToken.cancelled) return;
+      if (signal?.aborted) return;
 
       const start = performance.now();
 
-      while (renderedLines < totalLines) {
-        const orig = {
-          x: Util.getRandomInt(0, canvas.width),
-          y: Util.getRandomInt(0, canvas.height)
-        };
+      while (rendered < total) {
+        JPPainter.drawLine(ctx, {
+          strokeWidth,
+          color: ColorRegistry.random(colorSet),
+          from:  { x: Util.getRandomInt(0, canvas.width),  y: Util.getRandomInt(0, canvas.height) },
+          to:    { x: Util.getRandomInt(0, canvas.width),  y: Util.getRandomInt(0, canvas.height) },
+        });
 
-        const target = {
-          x: Util.getRandomInt(0, canvas.width),
-          y: Util.getRandomInt(0, canvas.height)
-        };
+        rendered++;
 
-        JPPainter.drawLine(
-          ctx,
-          PerformanceConfig.STROKE_WIDTH,
-          ColorHandler.getRandomColor(AppState.lastColorSet),
-          orig,
-          target
-        );
-
-        renderedLines += 1;
-
-        const hitBatchLimit = renderedLines % PerformanceConfig.BATCH_SIZE === 0;
-        const hitFrameBudget = performance.now() - start > PerformanceConfig.FRAME_BUDGET_MS;
-        if (hitBatchLimit || hitFrameBudget) break;
+        const hitBatch  = rendered % PerformanceConfig.BATCH_SIZE === 0;
+        const hitBudget = performance.now() - start > PerformanceConfig.FRAME_BUDGET_MS;
+        if (hitBatch || hitBudget) break;
       }
 
-      if (renderedLines < totalLines && !renderToken.cancelled) {
+      if (rendered >= total) {
+        onComplete?.();
+      } else if (!signal?.aborted) {
         requestAnimationFrame(drawChunk);
       }
     };
 
     requestAnimationFrame(drawChunk);
-  }
-
-  static paintMainTitle(colorSet) {
-    const mainTitle = document.getElementById('mainTitle');
-    if (!mainTitle) return;
-
-    let newMainTitle = '';
-    switch (colorSet) {
-      case 'BWR':
-        newMainTitle = "<strong><span class='black'>J</span><span class='white'>P</span><span class='red'>Canvas</span></strong>";
-        break;
-      case 'BWR2':
-        newMainTitle = "<strong><span class='blue'>J</span><span class='white'>P</span><span class='red'>Canvas</span></strong>";
-        break;
-      case 'RGB':
-        newMainTitle = "<strong><span class='red'>J</span><span class='green'>P</span><span class='blue'>Canvas</span></strong>";
-        break;
-      default:
-        newMainTitle = '<strong>JPCanvas</strong>';
-    }
-
-    mainTitle.innerHTML = newMainTitle;
   }
 }

--- a/js/preferences.js
+++ b/js/preferences.js
@@ -1,0 +1,37 @@
+const STORAGE_KEY = 'jpc_render_preferences_v1';
+
+export const DEFAULTS = Object.freeze({
+  lines: 9000,
+  stroke: 2,
+  colorSet: 'BWR',
+});
+
+export const UserPreferences = {
+  lines: DEFAULTS.lines,
+  stroke: DEFAULTS.stroke,
+  colorSet: DEFAULTS.colorSet,
+
+  load() {
+    try {
+      const data = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      if (Number.isFinite(data.lines))          this.lines    = data.lines;
+      if (Number.isFinite(data.stroke))         this.stroke   = data.stroke;
+      if (typeof data.colorSet === 'string')    this.colorSet = data.colorSet;
+    } catch { /* noop */ }
+  },
+
+  save() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      lines:    this.lines,
+      stroke:   this.stroke,
+      colorSet: this.colorSet,
+    }));
+  },
+
+  reset() {
+    this.lines    = DEFAULTS.lines;
+    this.stroke   = DEFAULTS.stroke;
+    this.colorSet = DEFAULTS.colorSet;
+    this.save();
+  },
+};

--- a/js/state.js
+++ b/js/state.js
@@ -1,7 +1,6 @@
 export const AppState = {
-  canvas: null,
-  ctx: null,
-  activeRenderToken: null,
-  resizeTimer: null,
-  lastColorSet: 'BWR'
+  canvas:           null,
+  ctx:              null,
+  renderController: null,  // AbortController for the active render
+  resizeTimer:      null,
 };

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,37 @@
+const TITLE_TEMPLATES = {
+  BWR:  "<strong><span class='black'>J</span><span class='white'>P</span><span class='red'>Canvas</span></strong>",
+  BWR2: "<strong><span class='blue'>J</span><span class='white'>P</span><span class='red'>Canvas</span></strong>",
+  RGB:  "<strong><span class='red'>J</span><span class='green'>P</span><span class='blue'>Canvas</span></strong>",
+};
+
+export const UI = {
+  setTitle(colorSet) {
+    const el = document.getElementById('mainTitle');
+    if (el) el.innerHTML = TITLE_TEMPLATES[colorSet] ?? '<strong>JPCanvas</strong>';
+  },
+
+  setRenderStatus(isRendering) {
+    const badge = document.getElementById('render-status');
+    if (!badge) return;
+    badge.textContent = isRendering ? 'Rendering...' : 'Ready';
+    badge.classList.toggle('is-rendering', isRendering);
+  },
+
+  setActivePreset(colorSet) {
+    document.querySelectorAll('[data-action="render"]').forEach((chip) => {
+      chip.classList.toggle('is-active', chip.getAttribute('data-colorset') === colorSet);
+    });
+  },
+
+  syncControls({ lines, stroke }) {
+    const lineInput   = document.getElementById('line-count');
+    const lineValue   = document.getElementById('line-count-value');
+    const strokeInput = document.getElementById('stroke-width');
+    const strokeValue = document.getElementById('stroke-width-value');
+
+    if (lineInput)   lineInput.value            = String(lines);
+    if (lineValue)   lineValue.textContent       = String(lines);
+    if (strokeInput) strokeInput.value           = String(stroke);
+    if (strokeValue) strokeValue.textContent     = String(stroke);
+  },
+};


### PR DESCRIPTION
PerformanceConfig now holds only immutable rendering constants (frozen).
User-adjustable values (lines, stroke, colorSet) move to a dedicated
preferences.js module that owns localStorage persistence and defaults,
eliminating the ad-hoc Default class and runtime config mutation.

https://claude.ai/code/session_0131GfBjrxDP8idKFW7BYXTF