### PR TITLE
feat: light museum wall theme + colored palette chip letters

### DIFF
--- a/css/jpc.css
+++ b/css/jpc.css
@@ -2,49 +2,66 @@
    JPCanvas — Museum × High-Tech
    Concept: digital gallery installation with data-terminal
    touches. Serif brand, monospace metadata, gold frame.
+   Light theme: warm museum walls, dark framed artwork.
    ────────────────────────────────────────────────────── */
 
 :root {
-  --bg:               #08070a;
-  --panel:            #0e0d11;
-  --panel-soft:       #141219;
-  --panel-border:     rgba(196, 152, 74, 0.14);
-  --panel-border-hi:  rgba(196, 152, 74, 0.50);
+  --bg:              #f2ede3;          /* crema cálida — pared de museo */
+  --panel:           #faf7f1;          /* panel ligeramente más claro que bg */
+  --panel-soft:      #ede8de;          /* inputs/áreas internas */
+  --panel-border:    rgba(160, 120, 50, 0.22);
+  --panel-border-hi: rgba(160, 120, 50, 0.55);
 
-  --text:             #ddd8cf;
-  --text-dim:         #6b6459;
-  --text-muted:       #3e3c38;
+  --text:            #1c1914;          /* marrón muy oscuro — placas de museo */
+  --text-dim:        #7a6e5a;          /* texto secundario */
+  --text-muted:      #b5a897;          /* texto tenue */
 
-  --gold:             #c4984a;
-  --gold-bright:      #ddb96a;
-  --gold-glow:        rgba(196, 152, 74, 0.18);
-  --gold-soft:        rgba(196, 152, 74, 0.07);
+  --gold:            #a0742a;          /* oro más oscuro para contraste sobre claro */
+  --gold-bright:     #b8882e;
+  --gold-glow:       rgba(160, 116, 42, 0.15);
+  --gold-soft:       rgba(160, 116, 42, 0.08);
 
   --font-serif: 'Playfair Display', Georgia, 'Times New Roman', serif;
   --font-mono:  'Space Mono', 'Courier New', monospace;
   --font-sans:  'Inter', system-ui, -apple-system, sans-serif;
 
-  /* Museum frames are rectilinear — minimal radius */
   --r: 2px;
 }
 
 * { box-sizing: border-box; }
 
+html { height: 100%; }
+
 body {
   margin: 0;
-  min-height: 100vh;
+  height: 100%;
+  overflow: hidden;
   font-family: var(--font-sans);
   color: var(--text);
   background-color: var(--bg);
-  /* warm overhead spotlight suggestion */
-  background-image: radial-gradient(ellipse 130% 55% at 50% -5%, #1d1508 0%, transparent 65%);
+  /* Textura de yeso/lino: rejilla muy fina — elegancia de museo */
+  background-image:
+    repeating-linear-gradient(
+      0deg,
+      transparent, transparent 3px,
+      rgba(0, 0, 0, 0.018) 3px, rgba(0, 0, 0, 0.018) 4px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      transparent, transparent 3px,
+      rgba(0, 0, 0, 0.012) 3px, rgba(0, 0, 0, 0.012) 4px
+    );
 }
 
 /* ── Shell ── */
 .app-shell {
+  height: 100vh;
+  height: 100dvh;
   width: min(1100px, 100% - 32px);
-  margin: 24px auto;
+  margin: 0 auto;
+  padding: 12px 0;
   display: grid;
+  grid-template-rows: auto 1fr auto;
   gap: 10px;
 }
 
@@ -58,7 +75,7 @@ body {
   flex-wrap: wrap;
   background: var(--panel);
   border: 1px solid var(--panel-border);
-  border-top-color: rgba(196, 152, 74, 0.55); /* gold crown line */
+  border-top-color: var(--panel-border-hi); /* gold crown line */
   border-radius: var(--r);
 }
 
@@ -97,29 +114,27 @@ body {
   color: var(--text-dim);
   font-family: var(--font-mono);
   font-size: 0.68rem;
-  letter-spacing: 0.1em;
+  font-weight: 700;
+  letter-spacing: 0.12em;
   cursor: pointer;
-  transition: border-color 0.2s, color 0.2s, background 0.2s;
+  transition: border-color 0.2s, background 0.2s;
 }
 
 .chip:hover {
   border-color: var(--gold);
-  color: var(--text);
 }
 
 .chip.is-active {
   border-color: var(--gold);
-  color: var(--gold-bright);
   background: var(--gold-soft);
-  /* thin inset fillet line — echoes the canvas frame */
-  box-shadow: inset 0 1px 0 rgba(196, 152, 74, 0.3);
+  box-shadow: inset 0 1px 0 rgba(160, 116, 42, 0.3);
 }
 
 .btn-regenerate {
   margin-left: 10px;
   padding: 6px 18px;
   background: var(--gold);
-  color: #08070a;
+  color: #faf7f1;
   border: 1px solid transparent;
   border-radius: var(--r);
   font-family: var(--font-mono);
@@ -142,21 +157,28 @@ body {
   padding: 16px;
   display: flex;
   flex-direction: column;
+  min-height: 0;
 }
 
 /* ── Canvas frame (museum + high-tech) ── */
 .canvas-container {
   position: relative;
   background: #030202;
-  border: 1px solid rgba(196, 152, 74, 0.55);
+  border: 1px solid rgba(160, 116, 42, 0.6);
   border-radius: 1px;
   /* Layers: outer frame → mat board → gold fillet → artwork */
   box-shadow:
     inset 0 0 0 14px #0c0a07,
-    inset 0 0 0 15px rgba(196, 152, 74, 0.20),
-    0 16px 70px rgba(0, 0, 0, 0.9),
-    0 2px 10px rgba(0, 0, 0, 0.6);
+    inset 0 0 0 15px rgba(160, 116, 42, 0.22),
+    0 20px 80px rgba(0, 0, 0, 0.35),
+    0 4px 16px rgba(0, 0, 0, 0.2);
   transition: box-shadow 0.8s ease;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
 }
 
 /* Alignment marks — high-tech targeting reticle on the mat */
@@ -189,14 +211,16 @@ body {
 .canvas-container.is-rendering {
   box-shadow:
     inset 0 0 0 14px #0c0a07,
-    inset 0 0 0 15px rgba(196, 152, 74, 0.32),
-    0 16px 70px rgba(0, 0, 0, 0.9),
-    0 0 50px rgba(196, 152, 74, 0.07);
+    inset 0 0 0 15px rgba(160, 116, 42, 0.34),
+    0 20px 80px rgba(0, 0, 0, 0.35),
+    0 0 50px rgba(160, 116, 42, 0.12);
 }
 
 #jpcanvas {
   display: block;
-  width: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
   height: auto;
 }
 
@@ -217,8 +241,8 @@ body {
   background: linear-gradient(
     to right,
     transparent,
-    rgba(196, 152, 74, 0.22) 25%,
-    rgba(196, 152, 74, 0.22) 75%,
+    rgba(160, 116, 42, 0.28) 25%,
+    rgba(160, 116, 42, 0.28) 75%,
     transparent
   );
 }
@@ -247,7 +271,7 @@ body {
   font-size: 0.6rem;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  color: var(--gold-bright);
+  color: var(--gold);
   opacity: 1;
   transition: opacity 0.4s ease;
 }
@@ -261,7 +285,7 @@ body {
   width: 5px;
   height: 5px;
   border-radius: 50%;
-  background: var(--gold-bright);
+  background: var(--gold);
   flex-shrink: 0;
   animation: pulse 1.4s ease-in-out infinite;
 }
@@ -283,7 +307,7 @@ body {
   display: grid;
   gap: 6px;
   background: var(--panel-soft);
-  border: 1px solid rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--panel-border);
   border-radius: var(--r);
   padding: 10px 12px;
 }
@@ -305,14 +329,14 @@ body {
 .control-value {
   font-family: var(--font-mono);
   font-size: 0.72rem;
-  color: var(--gold-bright);
+  color: var(--gold);
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
 .btn-reset {
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--panel-border);
   color: var(--text-muted);
   border-radius: var(--r);
   padding: 10px 14px;
@@ -326,8 +350,8 @@ body {
 }
 
 .btn-reset:hover {
-  border-color: rgba(196, 152, 74, 0.4);
-  color: var(--gold-bright);
+  border-color: var(--gold);
+  color: var(--gold);
 }
 
 /* ── Footer ── */
@@ -349,27 +373,27 @@ body {
 }
 
 .site-footer a:hover {
-  color: var(--gold-bright);
+  color: var(--gold);
 }
 
-/* ── Palette title color classes ── */
-/* "black" needs a lifted gray so it reads on the dark background */
-.black { color: #7a7672; }
-.blue  { color: #4d88ff; }
-.white { color: #e0dbd4; }
-.red   { color: #e83c3c; }
-.green { color: #38c244; }
+/* ── Palette color classes (chip letters + page title) ── */
+/* Calibradas para fondo claro — cada color legible sobre crema */
+.black { color: #1c1914; }   /* casi negro */
+.blue  { color: #1a4fbf; }   /* azul profundo */
+.white { color: #9a8e7e; }   /* gris cálido (blanco → invisible sobre claro) */
+.red   { color: #c42525; }   /* rojo saturado */
+.green { color: #1d7a2a; }   /* verde profundo */
 
 /* ── Responsive ── */
 @media (max-width: 640px) {
-  .app-shell      { width: min(1100px, 100% - 16px); margin: 10px auto; }
+  .app-shell      { width: min(1100px, 100% - 16px); padding: 8px 0; gap: 8px; }
   .topbar         { padding: 14px 16px; }
   .canvas-card    { padding: 10px; }
   .controls-panel { grid-template-columns: 1fr; }
   .canvas-container {
     box-shadow:
       inset 0 0 0 8px #0c0a07,
-      inset 0 0 0 9px rgba(196, 152, 74, 0.20),
-      0 8px 30px rgba(0, 0, 0, 0.9);
+      inset 0 0 0 9px rgba(160, 116, 42, 0.22),
+      0 8px 30px rgba(0, 0, 0, 0.3);
   }
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,3 +1,5 @@
+import { ColorRegistry } from './color.js';
+
 const TITLE_TEMPLATES = {
   BWR:  "<strong><span class='black'>J</span><span class='white'>P</span><span class='red'>Canvas</span></strong>",
   BWR2: "<strong><span class='blue'>J</span><span class='white'>P</span><span class='red'>Canvas</span></strong>",
@@ -25,7 +27,10 @@ export const UI = {
       btn.type = 'button';
       btn.dataset.action    = 'render';
       btn.dataset.colorset  = name;
-      btn.textContent       = name;
+      const colors = ColorRegistry.get(name);
+      btn.innerHTML = [...name]
+        .map((char, i) => colors[i] ? `<span class="${colors[i]}">${char}</span>` : char)
+        .join('');
       nav.insertBefore(btn, regenerateBtn);
     });
   },


### PR DESCRIPTION
CSS — switch to warm cream light theme:
- :root variables inverted for light background (--bg #f2ede3, --panel #faf7f1, dark text #1c1914, gold adjusted for contrast on light)
- body: CSS linen/plaster texture via repeating-linear-gradient + no-scroll layout (height:100%, overflow:hidden)
- .app-shell: 100dvh, grid rows auto|1fr|auto, no margin
- .canvas-container: flex:1 + min-height:0 + centered — dark artwork frame preserved with drop shadow suited for light background
- #jpcanvas: max-width/max-height:100% for aspect-ratio-safe scaling
- Color classes recalibrated for light bg (.white → warm gray #9a8e7e)
- .chip: bolder weight, color inherited from child spans
- .btn-reset/.control-item borders use --panel-border (visible on light)

JS (ui.js) — colored chip letters:
- Import ColorRegistry
- buildPresetChips: each character at index i gets a <span class=colorname>
  mapping to its palette color (BWR→black/white/red, BWR2→blue/white/red, RGB→red/green/blue); extra chars (e.g. "2") render as plain text

https://claude.ai/code/session_0131GfBjrxDP8idKFW7BYXTF