### PR TITLE
feat: white canvas surface with cream museum mat board

### DIFF
--- a/css/jpc.css
+++ b/css/jpc.css
@@ -147,12 +147,12 @@ body {
 /* ── Canvas frame (museum + high-tech) ── */
 .canvas-container {
   position: relative;
-  background: #030202;
+  background: #ffffff;
   border: 1px solid rgba(196, 152, 74, 0.55);
   border-radius: 1px;
-  /* Layers: outer frame → mat board → gold fillet → artwork */
+  /* Layers: outer frame → cream mat board → gold fillet → artwork */
   box-shadow:
-    inset 0 0 0 14px #0c0a07,
+    inset 0 0 0 14px #f5f0e6,
     inset 0 0 0 15px rgba(196, 152, 74, 0.20),
     0 16px 70px rgba(0, 0, 0, 0.9),
     0 2px 10px rgba(0, 0, 0, 0.6);
@@ -188,7 +188,7 @@ body {
 /* Subtle glow pulse while a composition is being painted */
 .canvas-container.is-rendering {
   box-shadow:
-    inset 0 0 0 14px #0c0a07,
+    inset 0 0 0 14px #f5f0e6,
     inset 0 0 0 15px rgba(196, 152, 74, 0.32),
     0 16px 70px rgba(0, 0, 0, 0.9),
     0 0 50px rgba(196, 152, 74, 0.07);

--- a/js/painter.js
+++ b/js/painter.js
@@ -21,6 +21,8 @@ export class JPPainter {
     if (!ctx || !canvas) return;
 
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
 
     let rendered = 0;
     const total  = Math.max(0, Number(totalLines) || 0);


### PR DESCRIPTION
css: .canvas-container background → #ffffff; mat board inset shadow changed from dark #0c0a07 to warm cream #f5f0e6 (mat-board tone), both in normal and is-rendering states.

js: painter.js fills canvas with white after clearRect so the surface is always opaque white regardless of container alpha.

https://claude.ai/code/session_0131GfBjrxDP8idKFW7BYXTF