### PR TITLE
fix: canvas fills frame and reacts to container resize

### DIFF
--- a/css/jpc.css
+++ b/css/jpc.css
@@ -175,9 +175,6 @@ body {
   transition: box-shadow 0.8s ease;
   flex: 1;
   min-height: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   overflow: hidden;
 }
 
@@ -218,10 +215,8 @@ body {
 
 #jpcanvas {
   display: block;
-  max-width: 100%;
-  max-height: 100%;
-  width: auto;
-  height: auto;
+  width: 100%;
+  height: 100%;
 }
 
 /* ── Placard (museum info card + controls) ── */

--- a/js/app.js
+++ b/js/app.js
@@ -10,17 +10,9 @@ function setupCanvas() {
   const canvas    = document.getElementById('jpcanvas');
   if (!container || !canvas) return;
 
-  const width   = Math.max(320, container.clientWidth || window.innerWidth || 320);
-  const vHeight = Math.max(window.innerHeight || 0, document.documentElement.clientHeight || 0);
-  const height  = Math.max(
-    PerformanceConfig.MIN_CANVAS_HEIGHT,
-    Math.min(PerformanceConfig.MAX_CANVAS_HEIGHT, vHeight - PerformanceConfig.CANVAS_VERTICAL_PADDING)
-  );
-
-  container.style.width  = `${width}px`;
-  container.style.height = `${height}px`;
-  canvas.width           = width;
-  canvas.height          = height;
+  // CSS flex controls container size — read actual rendered dimensions
+  canvas.width  = Math.max(320, container.clientWidth);
+  canvas.height = Math.max(PerformanceConfig.MIN_CANVAS_HEIGHT, container.clientHeight);
 
   AppState.canvas = canvas;
   AppState.ctx    = canvas.getContext('2d');
@@ -51,13 +43,19 @@ function render(colorSet) {
 }
 
 function attachResizeHandler() {
-  window.addEventListener('resize', () => {
+  const container = document.getElementById('containerCanvas');
+  if (!container) return;
+
+  let skipFirst = true;
+  new ResizeObserver(() => {
+    // Skip the initial observation fired on attach
+    if (skipFirst) { skipFirst = false; return; }
     clearTimeout(AppState.resizeTimer);
     AppState.resizeTimer = setTimeout(() => {
       setupCanvas();
       render(UserPreferences.colorSet);
     }, PerformanceConfig.RESIZE_DEBOUNCE_MS);
-  });
+  }).observe(container);
 }
 
 function attachNavigationHandlers() {


### PR DESCRIPTION
css: #jpcanvas width/height:100% so it fills the container exactly; remove display:flex centering from .canvas-container (no longer needed).

js: setupCanvas() removes container.style.width/height inline overrides that were preventing CSS flex from controlling container dimensions. Canvas dimensions now read from container.clientWidth/clientHeight.

attachResizeHandler() replaces window.resize with ResizeObserver on the canvas container — fires whenever the element itself changes size, skipping the initial synchronous observation to avoid a double render.

https://claude.ai/code/session_0131GfBjrxDP8idKFW7BYXTF