### PR TITLE
fix: show frame border and fix canvas resize responsiveness

### DIFF
--- a/css/jpc.css
+++ b/css/jpc.css
@@ -176,6 +176,7 @@ body {
   flex: 1;
   min-height: 0;
   overflow: hidden;
+  padding: 16px;
 }
 
 /* Alignment marks — high-tech targeting reticle on the mat */

--- a/js/app.js
+++ b/js/app.js
@@ -10,9 +10,9 @@ function setupCanvas() {
   const canvas    = document.getElementById('jpcanvas');
   if (!container || !canvas) return;
 
-  // CSS flex controls container size — read actual rendered dimensions
-  canvas.width  = Math.max(320, container.clientWidth);
-  canvas.height = Math.max(PerformanceConfig.MIN_CANVAS_HEIGHT, container.clientHeight);
+  // CSS flex + padding controls the container; canvas fills the content area (inside padding)
+  canvas.width  = Math.max(320, canvas.clientWidth);
+  canvas.height = Math.max(PerformanceConfig.MIN_CANVAS_HEIGHT, canvas.clientHeight);
 
   AppState.canvas = canvas;
   AppState.ctx    = canvas.getContext('2d');


### PR DESCRIPTION
css: canvas-container adds padding:16px so the 15px inset box-shadow frame (mat board + gold fillet) is visible; canvas uses width/height: 100% to fill the content area rather than auto-sizing.

js: setupCanvas() reads canvas.clientWidth/clientHeight (the CSS-laid-out dimensions inside the padding area) instead of setting inline width/height on the container, which was blocking CSS flex from resizing the element.

attachResizeHandler() replaces window.resize with a ResizeObserver on the canvas container so the canvas reacts when the element itself changes size.

https://claude.ai/code/session_0131GfBjrxDP8idKFW7BYXTF