### PR TITLE
docs: rewrite README and mark version v3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,123 +2,84 @@
 
 Generative art experiment in HTML5 Canvas by **cazucito**.
 
-JPCanvas renders abstract paintings by drawing thousands of random lines with configurable color palettes.
+JPCanvas renders abstract paintings by drawing thousands of random lines with configurable color palettes, presented in a museum-style walnut frame.
 
 ## Live demo
 
-- GitHub Pages: <https://cazucito.github.io/jpc/>
-
-## Current status
-
-- Version: **v2** (performance-focused baseline)
-- Branch baseline: `master`
-- Stable backup tag: `v2`
+<https://cazucito.github.io/jpc/>
 
 ## Features
 
-- Canvas-based generative drawing
-- Multiple palette iterations:
-  - `BWR` (black/white/red)
-  - `BWR2` (blue/white/red)
-  - `RGB` (red/green/blue)
-- Navbar actions to re-render with different palettes
-- Performance optimizations to reduce UI freezing:
-  - chunked rendering via `requestAnimationFrame`
-  - render cancellation when a new draw starts
-  - resize debounce
-  - bounded canvas sizing
+- Canvas-based generative drawing inside a walnut museum frame with gold fillet
+- Multiple color palettes:
+  - `BWR` — black / white / red
+  - `BWR2` — blue / white / red
+  - `RGB` — red / green / blue
+- Navbar palette switcher with dynamic color chips
+- Responsive canvas: fills frame and reacts to container resize
+- Chunked rendering via `requestAnimationFrame` to keep the UI responsive
+- Render cancellation when a new draw starts
+- Resize debounce
 
 ## Tech stack
 
-- HTML5
+- HTML5 Canvas
 - CSS3
-- Vanilla JavaScript (ES6 classes)
-- Bootstrap (layout/navigation)
+- Vanilla JavaScript (ES6 modules)
+- Bootstrap (layout / navigation)
 
 ## Project structure
 
-- `index.html` — app shell and navigation
-- `js/config.js` — runtime/performance config
-- `js/state.js` — shared app state
-- `js/util.js` — helper utilities
-- `js/color.js` — palette and color selection
-- `js/painter.js` — canvas rendering engine
-- `js/app.js` — ES module entrypoint + orchestration
-- `css/jpc.css` — project-specific styles
-- `css/`, `js/`, `fonts/` — Bootstrap/static assets
+```
+index.html        — app shell and navigation
+js/
+  config.js       — runtime / performance config
+  state.js        — shared app state
+  util.js         — helper utilities
+  color.js        — palette definitions and color selection
+  painter.js      — canvas rendering engine
+  app.js          — ES module entrypoint and orchestration
+  ui.js           — UI helpers (palette chips, frame logic)
+css/
+  jpc.css         — project-specific styles
+```
 
-See `ARCHITECTURE.md` for the refactor details.
+See [`ARCHITECTURE.md`](ARCHITECTURE.md) for the full refactor notes.
 
 ## Run locally
 
-Because this project uses browser JS and assets, run it with a local HTTP server (instead of opening `index.html` directly).
+This project uses ES modules, so it must be served over HTTP (not opened as a plain file).
 
-### Option A: Python
-
+**Python:**
 ```bash
 python3 -m http.server 8080
+# Open: http://localhost:8080
 ```
 
-Open: <http://localhost:8080>
-
-### Option B: Node
-
+**Node:**
 ```bash
 npx serve .
 ```
 
 ## How to use
 
-1. Open the page.
-2. The initial painting renders automatically.
-3. Use **Iterations** in the navbar to switch palette mode.
-4. Each selection triggers a fresh render.
+1. Open the page — the painting renders automatically.
+2. Use the **Iterations** menu in the navbar to switch palette.
+3. Each selection cancels the current render and starts a fresh one.
 
-## Performance notes
-
-If the page still feels heavy on very low-end devices:
-
-- reduce `DEFAULT_LINES` in `js/jpc.js`
-- reduce `BATCH_SIZE` in `js/jpc.js`
-- keep canvas dimensions bounded to viewport
-
-## GitHub Pages (v2 hardening)
-
-This repository is intended to publish from **GitHub Pages** as a project site:
+## GitHub Pages
 
 - URL: <https://cazucito.github.io/jpc/>
-- Source branch: `master`
-- Source folder: `/ (root)`
+- Branch: `master` → folder `/ (root)`
+- Static serving enabled via `.nojekyll`
+- `404.html` redirects to `index.html`
 
-Hardening added for deployment stability:
-
-- `.nojekyll` to serve static files directly
-- `404.html` redirect to `index.html` to reduce broken-route issues
-
-### Recommended Pages settings
-
-1. Go to **Settings → Pages**
-2. Under **Build and deployment**:
-   - Source: **Deploy from a branch**
-   - Branch: **master**
-   - Folder: **/ (root)**
-3. Save and wait ~1–2 minutes.
-
-### Troubleshooting
-
-- If old version appears, force refresh (`Ctrl/Cmd + Shift + R`)
-- Confirm branch/folder match exactly (`master` + `/root`)
-- Check Actions/Pages status if deployment is pending
-
-## Roadmap (near-term)
-
-- User-selectable custom colors
-- Extended README with screenshots and contribution guide
+**Setup:** Settings → Pages → Deploy from branch `master` / `/ (root)`.
 
 ## Author
 
-- GitHub: <https://github.com/cazucito>
+<https://github.com/cazucito>
 
 ---
 
-If you are working from issues: this README update addresses **Issue #2**.
+**Version: v3.1**


### PR DESCRIPTION
Clean, concise README reflecting the current state of the project (museum frame, ES modules, responsive canvas). Version badge added at the bottom.

https://claude.ai/code/session_0131GfBjrxDP8idKFW7BYXTF