### PR TITLE
Mobile Palettes Bottom Sheet v2

### DIFF
--- a/css/jpc.css
+++ b/css/jpc.css
@@ -751,15 +751,12 @@ body {
 .red   { color: #c42525; }   /* rojo saturado */
 .green { color: #1d7a2a; }   /* verde profundo */
 
-/* ── Mobile Controls Toggle ── */
-.mobile-controls-toggle {
+/* ── Mobile Toggle Buttons ── */
+.mobile-controls-toggle,
+.mobile-palettes-toggle {
   display: none;
   position: fixed;
-  bottom: calc(20px + env(safe-area-inset-bottom));
-  right: calc(20px + env(safe-area-inset-right));
   z-index: 100;
-  background: var(--gold);
-  color: #faf7f1;
   border: none;
   border-radius: 50px;
   padding: 14px 20px;
@@ -768,18 +765,90 @@ body {
   font-weight: 600;
   letter-spacing: 0.05em;
   cursor: pointer;
-  box-shadow: 0 4px 20px rgba(160, 116, 42, 0.4);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
   transition: all 0.2s ease;
   touch-action: manipulation;
   -webkit-tap-highlight-color: transparent;
 }
 
-.mobile-controls-toggle:active {
+.mobile-controls-toggle {
+  bottom: calc(20px + env(safe-area-inset-bottom));
+  right: calc(20px + env(safe-area-inset-right));
+  background: var(--gold);
+  color: #faf7f1;
+}
+
+.mobile-palettes-toggle {
+  bottom: calc(80px + env(safe-area-inset-bottom));
+  right: calc(20px + env(safe-area-inset-right));
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: #ffffff;
+}
+
+.mobile-controls-toggle:active,
+.mobile-palettes-toggle:active {
   transform: scale(0.95);
 }
 
-.mobile-controls-toggle .toggle-icon {
+.mobile-controls-toggle .toggle-icon,
+.mobile-palettes-toggle .toggle-icon {
   margin-right: 6px;
+}
+
+/* ── Mobile Palettes Grid ── */
+.mobile-palettes-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  padding: 8px 0;
+}
+
+.mobile-palette-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 8px;
+  background: var(--panel-soft);
+  border: 2px solid var(--panel-border);
+  border-radius: 12px;
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  transition: all 0.2s ease;
+}
+
+.mobile-palette-item:active {
+  transform: scale(0.95);
+}
+
+.mobile-palette-item.is-active {
+  border-color: var(--gold);
+  background: var(--gold-soft);
+  box-shadow: 0 4px 12px rgba(160, 116, 42, 0.2);
+}
+
+.mobile-palette-name {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--text);
+  text-align: center;
+}
+
+.mobile-palette-preview {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+}
+
+.mobile-palette-dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
 /* ── Mobile Bottom Sheet ── */
@@ -1081,11 +1150,14 @@ body {
   .brand-title    { font-size: 1.3rem; }
   .canvas-card    { padding: 10px; }
   
-  /* Hide desktop controls on mobile */
+  /* Hide desktop controls and palette chips on mobile */
   .controls-panel { display: none; }
+  .palette-section .controls { display: none; }
+  .custom-colors-panel { display: none !important; }
   
-  /* Show mobile toggle */
-  .mobile-controls-toggle {
+  /* Show mobile toggles */
+  .mobile-controls-toggle,
+  .mobile-palettes-toggle {
     display: flex;
     align-items: center;
   }

--- a/index.html
+++ b/index.html
@@ -48,6 +48,12 @@
         <span class="toggle-text">Controls</span>
       </button>
 
+      <!-- Mobile Palettes Toggle -->
+      <button id="mobile-palettes-toggle" type="button" class="mobile-palettes-toggle" aria-label="Open palettes" aria-expanded="false" aria-controls="mobile-palettes-sheet">
+        <span class="toggle-icon">🎨</span>
+        <span class="toggle-text">Palettes</span>
+      </button>
+
       <section class="canvas-card" aria-live="polite">
         <div id="containerCanvas" class="canvas-container">
           <canvas id="jpcanvas">NOT SUPPORTED</canvas>
@@ -163,6 +169,25 @@
                 <button id="mobile-download" type="button" class="mobile-btn mobile-btn-download">⬇ Download</button>
                 <button id="mobile-share" type="button" class="mobile-btn mobile-btn-share">⬆ Share</button>
               </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Mobile Palettes Bottom Sheet -->
+      <div id="mobile-palettes-sheet" class="mobile-bottom-sheet" role="dialog" aria-modal="true" aria-labelledby="palettes-sheet-title" aria-hidden="true">
+        <div class="bottom-sheet-backdrop"></div>
+        <div class="bottom-sheet-content">
+          <div class="bottom-sheet-handle" role="button" tabindex="0" aria-label="Swipe down to close">
+            <span class="handle-bar"></span>
+          </div>
+          <div class="bottom-sheet-header">
+            <h3 id="palettes-sheet-title" class="bottom-sheet-title">Palettes</h3>
+            <button id="close-palettes-sheet" type="button" class="bottom-sheet-close" aria-label="Close">✕</button>
+          </div>
+          <div class="bottom-sheet-body">
+            <div id="mobile-palettes-grid" class="mobile-palettes-grid">
+              <!-- Palettes injected dynamically -->
             </div>
           </div>
         </div>

--- a/js/app.js
+++ b/js/app.js
@@ -505,6 +505,163 @@ function attachMobileControlHandlers() {
   });
 }
 
+// ── Mobile Palettes Bottom Sheet ──
+function initMobilePalettesSheet() {
+  const toggleBtn = document.getElementById('mobile-palettes-toggle');
+  const closeBtn = document.getElementById('close-palettes-sheet');
+  const sheet = document.getElementById('mobile-palettes-sheet');
+  const grid = document.getElementById('mobile-palettes-grid');
+  
+  if (!toggleBtn || !sheet || !grid) return;
+
+  function buildPalettesGrid() {
+    grid.innerHTML = '';
+    const palettes = ColorRegistry.names();
+    
+    palettes.forEach(name => {
+      const colors = ColorRegistry.get(name);
+      const item = document.createElement('button');
+      item.className = 'mobile-palette-item';
+      item.type = 'button';
+      item.dataset.palette = name;
+      item.setAttribute('aria-label', `Select ${name} palette`);
+      
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'mobile-palette-name';
+      nameSpan.textContent = name;
+      
+      const preview = document.createElement('div');
+      preview.className = 'mobile-palette-preview';
+      
+      colors.forEach(color => {
+        const dot = document.createElement('span');
+        dot.className = 'mobile-palette-dot';
+        dot.style.backgroundColor = color;
+        preview.appendChild(dot);
+      });
+      
+      item.appendChild(nameSpan);
+      item.appendChild(preview);
+      
+      item.addEventListener('click', () => {
+        grid.querySelectorAll('.mobile-palette-item').forEach(el => {
+          el.classList.remove('is-active');
+        });
+        item.classList.add('is-active');
+        render(name);
+        closeSheet();
+      });
+      
+      grid.appendChild(item);
+    });
+    
+    updateActivePalette(UserPreferences.colorSet);
+  }
+
+  function updateActivePalette(activeName) {
+    grid.querySelectorAll('.mobile-palette-item').forEach(item => {
+      item.classList.toggle('is-active', item.dataset.palette === activeName);
+    });
+  }
+
+  const backdrop = sheet.querySelector('.bottom-sheet-backdrop');
+  const handle = sheet.querySelector('.bottom-sheet-handle');
+  let previousActiveElement = null;
+  let previousOverflow = '';
+  
+  const focusableSelectors = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+  
+  function getFocusableElements() {
+    return Array.from(sheet.querySelectorAll(focusableSelectors)).filter(el => 
+      !el.hasAttribute('disabled') && el.offsetParent !== null
+    );
+  }
+
+  function trapFocus(e) {
+    const focusableElements = getFocusableElements();
+    if (focusableElements.length === 0) return;
+    
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (e.key === 'Tab') {
+      if (e.shiftKey && document.activeElement === firstElement) {
+        e.preventDefault();
+        lastElement.focus();
+      } else if (!e.shiftKey && document.activeElement === lastElement) {
+        e.preventDefault();
+        firstElement.focus();
+      }
+    }
+  }
+
+  function openSheet() {
+    previousActiveElement = document.activeElement;
+    previousOverflow = document.body.style.overflow;
+    sheet.classList.add('is-open');
+    sheet.setAttribute('aria-hidden', 'false');
+    toggleBtn.setAttribute('aria-expanded', 'true');
+    document.body.style.overflow = 'hidden';
+    buildPalettesGrid();
+    
+    const focusableElements = getFocusableElements();
+    if (focusableElements.length > 0) {
+      focusableElements[0].focus();
+    }
+    
+    sheet.addEventListener('keydown', trapFocus);
+  }
+
+  function closeSheet() {
+    if (!sheet.classList.contains('is-open') || sheet.getAttribute('aria-hidden') === 'true') {
+      return;
+    }
+    sheet.classList.remove('is-open');
+    sheet.setAttribute('aria-hidden', 'true');
+    toggleBtn.setAttribute('aria-expanded', 'false');
+    document.body.style.overflow = previousOverflow;
+    sheet.removeEventListener('keydown', trapFocus);
+    
+    if (previousActiveElement) {
+      previousActiveElement.focus();
+    }
+  }
+
+  toggleBtn.addEventListener('click', openSheet);
+  closeBtn?.addEventListener('click', closeSheet);
+  backdrop?.addEventListener('click', closeSheet);
+  
+  handle?.addEventListener('click', closeSheet);
+  handle?.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      closeSheet();
+    }
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && sheet.classList.contains('is-open')) {
+      closeSheet();
+    }
+  });
+
+  let touchStartY = 0;
+  handle?.addEventListener('touchstart', (e) => {
+    touchStartY = e.touches[0].clientY;
+  }, { passive: true });
+
+  handle?.addEventListener('touchmove', (e) => {
+    const touchY = e.touches[0].clientY;
+    if (touchY - touchStartY > 50) {
+      closeSheet();
+    }
+  }, { passive: true });
+
+  buildPalettesGrid();
+  
+  return updateActivePalette;
+}
+
 export function init() {
   UserPreferences.load();
   
@@ -538,6 +695,7 @@ export function init() {
   attachColorPickerHandlers();
   initMobileBottomSheet();
   attachMobileControlHandlers();
+  initMobilePalettesSheet();
   
   // Update URL when preferences change
   const originalSave = UserPreferences.save.bind(UserPreferences);


### PR DESCRIPTION
## Mobile Palettes Bottom Sheet

Resolves the issue where palette chips occupy too much vertical space on mobile.

### Changes

**Mobile UX:**
- New floating button Palettes (positioned above Controls button)
- Bottom sheet with 3x3 grid of all palettes
- Each palette shows: name + 3 color dots preview
- Desktop chips hidden on mobile (<768px)

**Features:**
- Same interaction pattern as Controls bottom sheet
- Focus trapping and keyboard navigation
- Swipe-down to close
- Works alongside animation mode

**Accessibility:**
- ARIA attributes (role=dialog, aria-modal, aria-expanded)
- 44px minimum touch targets
- Keyboard accessible (Enter/Space to select, Escape to close)

### Screenshot
Mobile view shows stacked floating buttons (Palettes above Controls) instead of wrapping palette chips.

Consistent UX with Controls bottom sheet pattern.